### PR TITLE
Update push-to-oci.yaml to include tags in branch filtering

### DIFF
--- a/.github/workflows/push-to-oci.yaml
+++ b/.github/workflows/push-to-oci.yaml
@@ -2,7 +2,10 @@ name: Push to OCI
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/push-to-oci.yaml
+++ b/.github/workflows/push-to-oci.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'v*.*.*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This pull request updates the push-to-oci.yaml file to include tags in the branch filtering. Previously, only the main branch was included, but now any branch starting with 'v' will also be included. This change ensures that tags are properly filtered and included in the push to OCI process.